### PR TITLE
fix(AdminInterfaceHook): missing router interface params in constructor

### DIFF
--- a/Config/config.xml
+++ b/Config/config.xml
@@ -17,7 +17,6 @@
     <hooks>
         <hook id="dealer.admin.hook" class="Dealer\Hook\AdminInterfaceHook" scope="request">
             <tag name="hook.event_listener" event="main.in-top-menu-items" type="back" method="onMainTopMenuTools"/>
-            <argument type="service" id="router.Dealer"/>
             <argument type="service" id="thelia.securityContext"/>
         </hook>
         <hook id="dealer.internal.hook" class="Dealer\Hook\InternalHook" scope="request">

--- a/Config/module.xml
+++ b/Config/module.xml
@@ -16,7 +16,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>3.0.1</version>
+    <version>3.0.2</version>
     <author>
         <name>Penalver Antony</name>
         <email>apenalver@openstudio.fr</email>

--- a/Hook/AdminInterfaceHook.php
+++ b/Hook/AdminInterfaceHook.php
@@ -1,4 +1,5 @@
 <?php
+
 /*************************************************************************************/
 /*      This file is part of the Thelia package.                                     */
 /*                                                                                   */
@@ -14,8 +15,6 @@
 namespace Dealer\Hook;
 
 use Dealer\Dealer;
-use Symfony\Component\Routing\Router;
-use Thelia\Core\Event\Hook\HookRenderBlockEvent;
 use Thelia\Core\Event\Hook\HookRenderEvent;
 use Thelia\Core\Hook\BaseHook;
 use Thelia\Core\Security\AccessManager;
@@ -27,6 +26,7 @@ use Thelia\Core\Translation\Translator;
  */
 class AdminInterfaceHook extends BaseHook
 {
+    /** @var  SecurityContext */
     protected $securityContext;
 
     public function __construct(SecurityContext $securityContext)


### PR DESCRIPTION
Causing exception:

````
Dealer\Hook\AdminInterfaceHook::__construct(): 
Argument #1 ($securityContext) must be of type Thelia\Core\Security\SecurityContext, Symfony\Component\Routing\Router given, 
called in /Users/mbruchet/sites/etains-du-prince/var/cache/dev/ContainerFzoyHRj/getDealer_Admin_HookService.php 
on line 24
````