### PR TITLE
fix: align DealerImage::setVisible signature with FileModelInterface

### DIFF
--- a/Model/DealerImage.php
+++ b/Model/DealerImage.php
@@ -96,13 +96,7 @@ class DealerImage extends BaseDealerImage implements FileModelInterface
         return DealerImageQuery::create();
     }
 
-    /**
-     * Set the current locale
-     *
-     * @param  bool $visible true if the file is visible, false otherwise
-     * @return FileModelInterface
-     */
-    public function setVisible($visible)
+    public function setVisible(?int $visible = null): static
     {
         return $this;
     }


### PR DESCRIPTION
Le core a durci `FileModelInterface::setVisible` en `setVisible(?int $visible = null): static`. Aligne DealerImage pour rétablir la compatibilité (Symfony 7.4 / dernier core).